### PR TITLE
feat: add scheduled slack cleanup workflow

### DIFF
--- a/.github/workflows/slack-cleanup.yml
+++ b/.github/workflows/slack-cleanup.yml
@@ -1,0 +1,18 @@
+name: Slack Cleanup
+on:
+  schedule:
+    # Run every 6 hours
+    - cron: "0 */6 * * *"
+  workflow_dispatch:
+permissions: {}
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - name: slack cleanup
+        uses: brave/security-action/actions/cleanup@main
+        with:
+          github_token: ${{ secrets.SLACK_CLEANUP_GITHUB_TOKEN }}
+          slack_token: ${{ secrets.HOTSPOTS_SLACK_TOKEN }}
+          debug: false


### PR DESCRIPTION
## Summary
- Adds a scheduled workflow that runs `brave/security-action/actions/cleanup` every 6 hours
- Cleans stale security-action Slack messages via cron instead of on every PR scan
- Requires `SLACK_CLEANUP_GITHUB_TOKEN` org secret (PAT with cross-repo read access for PR review threads and timeline events)

Depends on https://github.com/brave/security-action/pull/927